### PR TITLE
Add `TIMER_LOOP` command for automatically logging the elapsed time from `TIMER_READ`

### DIFF
--- a/src/command.zig
+++ b/src/command.zig
@@ -535,6 +535,7 @@ fn timerLoop(params: [][]const u8) !void {
         );
     };
     timer_log_file = try std.fs.cwd().createFile(file_path, .{});
+    try timer_log_file.?.writer().print("elapsed time", .{});
     timer_log_data = try CircularBuffer(f64).initCapacity(
         allocator,
         iteration,

--- a/src/command.zig
+++ b/src/command.zig
@@ -535,7 +535,7 @@ fn timerLoop(params: [][]const u8) !void {
         );
     };
     timer_log_file = try std.fs.cwd().createFile(file_path, .{});
-    try timer_log_file.?.writer().print("elapsed time", .{});
+    try timer_log_file.?.writer().print("elapsed time\n", .{});
     timer_log_data = try CircularBuffer(f64).initCapacity(
         allocator,
         iteration,

--- a/src/command.zig
+++ b/src/command.zig
@@ -523,7 +523,7 @@ fn timerLoop(params: [][]const u8) !void {
 
         break :p try std.fmt.bufPrint(
             &path_buffer,
-            "mmc-register-{}.{:0>2}.{:0>2}-{:0>2}.{:0>2}.{:0>2}.csv",
+            "time-logging-{}.{:0>2}.{:0>2}-{:0>2}.{:0>2}.{:0>2}.csv",
             .{
                 ymd.year,
                 ymd.month.number(),

--- a/src/command.zig
+++ b/src/command.zig
@@ -499,6 +499,9 @@ fn timerRead(_: [][]const u8) !void {
                     .{},
                 );
                 timer_log_file.?.close();
+                timer_log_file = null;
+                timer_iteration = null;
+                timer_log_data = null;
                 return error.MaximumTimerLoopExceeded;
             }
         }


### PR DESCRIPTION
The function require these parameters:
- iterations: number of iteration that will make TIMER_READ return an error
- path: the logging path

The function will set the CircularBuffer variable to store the time from TIMER_READ. It also create a logging file to save the data after the TIMER_READ runs the same number as the iterations parameter.

This PR will also bump the version