### PR TITLE
Fix `exit` command does not deinit modules

### DIFF
--- a/src/command.zig
+++ b/src/command.zig
@@ -631,9 +631,6 @@ fn clear(_: [][]const u8) !void {
 }
 
 fn exit(_: [][]const u8) !void {
-    if (client_cli.main_socket) |s| {
-        std.log.debug("closing {}", .{try s.getLocalEndPoint()});
-        s.close();
-    }
+    deinit();
     std.process.exit(1);
 }

--- a/src/command/client_cli.zig
+++ b/src/command/client_cli.zig
@@ -624,7 +624,7 @@ pub fn init(c: Config) !void {
         \\takes longer than the specified timeout duration. The timeout must be
         \\provided in milliseconds.
         ,
-        .execute = &clientCarrrierWaitPull,
+        .execute = &clientCarrierWaitPull,
     });
     errdefer command.registry.orderedRemove("WAIT_PULL_CARRIER");
     try command.registry.put(.{
@@ -663,7 +663,7 @@ pub fn init(c: Config) !void {
 pub fn deinit() void {
     if (main_socket) |s| {
         s.close();
-        disconnectedClearence(s) catch {};
+        disconnectedClearance(s) catch {};
     }
     line_names = undefined;
     line_accelerations = undefined;
@@ -691,14 +691,14 @@ fn serverVersion(_: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
         const msg_len = s.receive(&buffer) catch |e| {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
         const ServerVersion = protobuf_msg.ServerVersion;
@@ -746,7 +746,7 @@ fn clientConnect(params: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
         const LineConfig = protobuf_msg.LineConfig;
@@ -835,7 +835,7 @@ fn clientConnect(params: [][]const u8) !void {
     }
 }
 
-fn disconnectedClearence(s: network.Socket) !void {
+fn disconnectedClearance(s: network.Socket) !void {
     for (line_names) |name| {
         allocator.free(name);
     }
@@ -852,7 +852,7 @@ fn disconnectedClearence(s: network.Socket) !void {
 fn clientDisconnect(_: [][]const u8) !void {
     if (main_socket) |s| {
         s.close();
-        try disconnectedClearence(s);
+        try disconnectedClearance(s);
     } else return error.ServerNotConnected;
 }
 
@@ -883,7 +883,7 @@ fn clientAutoInitialize(params: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
     } else return error.ServerNotConnected;
@@ -1175,7 +1175,7 @@ fn clientStationX(params: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
         var buffer: [128]u8 = undefined;
@@ -1183,7 +1183,7 @@ fn clientStationX(params: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
         const x = try parseRegisterX(
@@ -1321,7 +1321,7 @@ fn clientStationY(params: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
         var buffer: [128]u8 = undefined;
@@ -1329,7 +1329,7 @@ fn clientStationY(params: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
         const y = try parseRegisterY(
@@ -1603,7 +1603,7 @@ fn clientStationWr(params: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
         var buffer: [128]u8 = undefined;
@@ -1611,7 +1611,7 @@ fn clientStationWr(params: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
         const wr = try parseRegisterWr(
@@ -1747,7 +1747,7 @@ fn clientStationWw(params: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
         var buffer: [128]u8 = undefined;
@@ -1755,7 +1755,7 @@ fn clientStationWw(params: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
         const ww = try parseRegisterWw(
@@ -1801,7 +1801,7 @@ fn clientAxisCarrier(params: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
         var buffer: [128]u8 = undefined;
@@ -1809,7 +1809,7 @@ fn clientAxisCarrier(params: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
         const carrier = try parseCarrierStatus(
@@ -1865,7 +1865,7 @@ fn clientAssertLocation(params: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
         var buffer: [128]u8 = undefined;
@@ -1873,7 +1873,7 @@ fn clientAssertLocation(params: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
         const carrier = try parseCarrierStatus(
@@ -1917,7 +1917,7 @@ fn clientAxisReleaseServo(params: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
     } else return error.ServerNotConnected;
@@ -1966,7 +1966,7 @@ fn clientClearErrors(params: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
         try waitReceived(@intCast(line_id - 1));
@@ -2016,7 +2016,7 @@ fn clientClearCarrierInfo(params: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
         try waitReceived(@intCast(line_id - 1));
@@ -2054,7 +2054,7 @@ fn clientCarrierLocation(params: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
         var buffer: [128]u8 = undefined;
@@ -2062,7 +2062,7 @@ fn clientCarrierLocation(params: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
         const carrier = try parseCarrierStatus(
@@ -2113,7 +2113,7 @@ fn clientCarrierAxis(params: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
         var buffer: [128]u8 = undefined;
@@ -2121,7 +2121,7 @@ fn clientCarrierAxis(params: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
         const carrier = try parseCarrierStatus(
@@ -2195,7 +2195,7 @@ fn clientHallStatus(params: [][]const u8) !void {
                 std.log.debug("{s}", .{@errorName(e)});
                 std.log.err("ConnectionClosedByServer", .{});
                 s.close();
-                try disconnectedClearence(s);
+                try disconnectedClearance(s);
                 return;
             };
             var buffer: [128]u8 = undefined;
@@ -2203,7 +2203,7 @@ fn clientHallStatus(params: [][]const u8) !void {
                 std.log.debug("{s}", .{@errorName(e)});
                 std.log.err("ConnectionClosedByServer", .{});
                 s.close();
-                try disconnectedClearence(s);
+                try disconnectedClearance(s);
                 return;
             };
             const hall_sensor = try parseHallStatus(
@@ -2245,7 +2245,7 @@ fn clientHallStatus(params: [][]const u8) !void {
                 std.log.debug("{s}", .{@errorName(e)});
                 std.log.err("ConnectionClosedByServer", .{});
                 s.close();
-                try disconnectedClearence(s);
+                try disconnectedClearance(s);
                 return;
             };
             var buffer: [128]u8 = undefined;
@@ -2253,7 +2253,7 @@ fn clientHallStatus(params: [][]const u8) !void {
                 std.log.debug("{s}", .{@errorName(e)});
                 std.log.err("ConnectionClosedByServer", .{});
                 s.close();
-                try disconnectedClearence(s);
+                try disconnectedClearance(s);
                 return;
             };
             const hall_sensor = try parseHallStatus(
@@ -2328,7 +2328,7 @@ fn clientAssertHall(params: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
         var buffer: [128]u8 = undefined;
@@ -2336,7 +2336,7 @@ fn clientAssertHall(params: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
         const hall_sensor = try parseHallStatus(
@@ -2375,7 +2375,7 @@ fn clientMclReset(_: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
     } else return error.ServerNotConnected;
@@ -2518,7 +2518,7 @@ fn clientWaitIsolate(params: [][]const u8) !void {
                 std.log.debug("{s}", .{@errorName(e)});
                 std.log.err("ConnectionClosedByServer", .{});
                 s.close();
-                try disconnectedClearence(s);
+                try disconnectedClearance(s);
                 return;
             };
             var buffer: [128]u8 = undefined;
@@ -2526,7 +2526,7 @@ fn clientWaitIsolate(params: [][]const u8) !void {
                 std.log.debug("{s}", .{@errorName(e)});
                 std.log.err("ConnectionClosedByServer", .{});
                 s.close();
-                try disconnectedClearence(s);
+                try disconnectedClearance(s);
                 return;
             };
             const carrier = try parseCarrierStatus(
@@ -2583,7 +2583,7 @@ fn clientWaitMoveCarrier(params: [][]const u8) !void {
                 std.log.debug("{s}", .{@errorName(e)});
                 std.log.err("ConnectionClosedByServer", .{});
                 s.close();
-                try disconnectedClearence(s);
+                try disconnectedClearance(s);
                 return;
             };
             var buffer: [128]u8 = undefined;
@@ -2591,7 +2591,7 @@ fn clientWaitMoveCarrier(params: [][]const u8) !void {
                 std.log.debug("{s}", .{@errorName(e)});
                 std.log.err("ConnectionClosedByServer", .{});
                 s.close();
-                try disconnectedClearence(s);
+                try disconnectedClearance(s);
                 return;
             };
             const carrier = try parseCarrierStatus(
@@ -2929,7 +2929,7 @@ fn clientCarrierPullBackward(params: [][]const u8) !void {
     );
 }
 
-fn clientCarrrierWaitPull(params: [][]const u8) !void {
+fn clientCarrierWaitPull(params: [][]const u8) !void {
     const line_name: []const u8 = params[0];
     const carrier_id = try std.fmt.parseInt(u10, params[1], 0);
     const timeout = if (params[2].len > 0)
@@ -2969,7 +2969,7 @@ fn clientCarrrierWaitPull(params: [][]const u8) !void {
                 std.log.debug("{s}", .{@errorName(e)});
                 std.log.err("ConnectionClosedByServer", .{});
                 s.close();
-                try disconnectedClearence(s);
+                try disconnectedClearance(s);
                 return;
             };
             var buffer: [128]u8 = undefined;
@@ -2977,7 +2977,7 @@ fn clientCarrrierWaitPull(params: [][]const u8) !void {
                 std.log.debug("{s}", .{@errorName(e)});
                 std.log.err("ConnectionClosedByServer", .{});
                 s.close();
-                try disconnectedClearence(s);
+                try disconnectedClearance(s);
                 return;
             };
             const carrier = try parseCarrierStatus(
@@ -3017,7 +3017,7 @@ fn clientCarrierStopPull(params: [][]const u8) !void {
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
     } else return error.ServerNotConnected;
@@ -3062,7 +3062,7 @@ fn clientWaitAxisEmpty(params: [][]const u8) !void {
                 std.log.debug("{s}", .{@errorName(e)});
                 std.log.err("ConnectionClosedByServer", .{});
                 s.close();
-                try disconnectedClearence(s);
+                try disconnectedClearance(s);
                 return;
             };
             var buffer: [128]u8 = undefined;
@@ -3070,7 +3070,7 @@ fn clientWaitAxisEmpty(params: [][]const u8) !void {
                 std.log.debug("{s}", .{@errorName(e)});
                 std.log.err("ConnectionClosedByServer", .{});
                 s.close();
-                try disconnectedClearence(s);
+                try disconnectedClearance(s);
                 return;
             };
             const wr = try parseRegisterWr(
@@ -3090,14 +3090,14 @@ fn clientWaitAxisEmpty(params: [][]const u8) !void {
                 std.log.debug("{s}", .{@errorName(e)});
                 std.log.err("ConnectionClosedByServer", .{});
                 s.close();
-                try disconnectedClearence(s);
+                try disconnectedClearance(s);
                 return;
             };
             const x_msg_len = s.receive(&buffer) catch |e| {
                 std.log.debug("{s}", .{@errorName(e)});
                 std.log.err("ConnectionClosedByServer", .{});
                 s.close();
-                try disconnectedClearence(s);
+                try disconnectedClearance(s);
                 return;
             };
             const x = try parseRegisterX(
@@ -3144,7 +3144,7 @@ fn sendMessageAndWaitReceived(
             std.log.debug("{s}", .{@errorName(e)});
             std.log.err("ConnectionClosedByServer", .{});
             s.close();
-            try disconnectedClearence(s);
+            try disconnectedClearance(s);
             return;
         };
 
@@ -3166,7 +3166,7 @@ fn sendMessageAndWaitReceived(
                 std.log.debug("{s}", .{@errorName(e)});
                 std.log.err("ConnectionClosedByServer", .{});
                 s.close();
-                try disconnectedClearence(s);
+                try disconnectedClearance(s);
                 return;
             };
             var buffer: [128]u8 = undefined;
@@ -3174,7 +3174,7 @@ fn sendMessageAndWaitReceived(
                 std.log.debug("{s}", .{@errorName(e)});
                 std.log.err("ConnectionClosedByServer", .{});
                 s.close();
-                try disconnectedClearence(s);
+                try disconnectedClearance(s);
                 return;
             };
             const command_status = try parseCommandStatus(
@@ -3222,7 +3222,7 @@ fn waitReceived(line_idx: mcl.Line.Index) !void {
                 std.log.debug("{s}", .{@errorName(e)});
                 std.log.err("ConnectionClosedByServer", .{});
                 s.close();
-                try disconnectedClearence(s);
+                try disconnectedClearance(s);
                 return;
             };
             var buffer: [128]u8 = undefined;
@@ -3230,7 +3230,7 @@ fn waitReceived(line_idx: mcl.Line.Index) !void {
                 std.log.debug("{s}", .{@errorName(e)});
                 std.log.err("ConnectionClosedByServer", .{});
                 s.close();
-                try disconnectedClearence(s);
+                try disconnectedClearance(s);
                 return;
             };
             const command_status = try parseCommandStatus(

--- a/src/command/client_cli.zig
+++ b/src/command/client_cli.zig
@@ -665,9 +665,6 @@ pub fn deinit() void {
         s.close();
         disconnectedClearance(s) catch {};
     }
-    line_names = undefined;
-    line_accelerations = undefined;
-    line_speeds = undefined;
     arena.deinit();
     network.deinit();
     std.log.debug("mmc-client de-initialized", .{});
@@ -847,6 +844,9 @@ fn disconnectedClearance(s: network.Socket) !void {
         .{try s.getRemoteEndPoint()},
     );
     main_socket = null;
+    line_names = undefined;
+    line_accelerations = undefined;
+    line_speeds = undefined;
 }
 
 fn clientDisconnect(_: [][]const u8) !void {

--- a/src/command/client_cli.zig
+++ b/src/command/client_cli.zig
@@ -662,6 +662,7 @@ pub fn init(c: Config) !void {
 
 pub fn deinit() void {
     if (main_socket) |s| {
+        s.close();
         disconnectedClearence(s) catch {};
     }
     line_names = undefined;
@@ -835,7 +836,6 @@ fn clientConnect(params: [][]const u8) !void {
 }
 
 fn disconnectedClearence(s: network.Socket) !void {
-    s.close();
     for (line_names) |name| {
         allocator.free(name);
     }
@@ -844,7 +844,7 @@ fn disconnectedClearence(s: network.Socket) !void {
     allocator.free(line_speeds);
     std.log.info(
         "Disconnected from server {}",
-        .{try main_socket.?.getRemoteEndPoint()},
+        .{try s.getRemoteEndPoint()},
     );
     main_socket = null;
 }


### PR DESCRIPTION
It turns out that `std.process.exit(1)` force the exit process without going back to main loop. Thus, the deinit need to be called inside the `command.exit()` function

closes #64 