### PR TITLE
Fix connection stuck in socket operation

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -17,8 +17,8 @@
             .hash = "chrono-0.1.0-uVd76GvCAwAvWrHupKdlB_UrmfZHRuVP-P4Xi_G8hz3R",
         },
         .mmc_config = .{
-            .url = "https://github.com/pmotionf/mmc-config/archive/6d61d65.tar.gz",
-            .hash = "mmc_config-0.0.1-DKyEyaq5AABQs56gjSAGJetGm1WdfOxcXQUZjfJlczhY",
+            .url = "https://github.com/pmotionf/mmc-config/archive/1bae337.tar.gz",
+            .hash = "mmc_config-0.0.1-DKyEybe5AAC9oU2yJMpgnCGozCBEptuwZD_rc-XmRGQA",
         },
     },
     .paths = .{""},

--- a/src/command/mcl.zig
+++ b/src/command/mcl.zig
@@ -2324,14 +2324,13 @@ fn startLogRegisters(params: [][]const u8) !void {
     std.log.info("logging registers data..", .{});
     var timer = try std.time.Timer.start();
     while (true) {
-        command.checkCommandInterrupt() catch {
-            std.log.info("saving logging data..", .{});
-            break;
-        };
-        logging_data.writeItemOverwrite(try logRegisters(
+        logging_data.writeItemOverwrite(logRegisters(
             log_time_start,
             &timer,
-        ));
+        ) catch {
+            std.log.info("saving logging data..", .{});
+            break;
+        });
     }
     try logToString(
         &logging_data,

--- a/src/command/mcl.zig
+++ b/src/command/mcl.zig
@@ -2324,13 +2324,14 @@ fn startLogRegisters(params: [][]const u8) !void {
     std.log.info("logging registers data..", .{});
     var timer = try std.time.Timer.start();
     while (true) {
-        logging_data.writeItemOverwrite(logRegisters(
-            log_time_start,
-            &timer,
-        ) catch {
+        command.checkCommandInterrupt() catch {
             std.log.info("saving logging data..", .{});
             break;
-        });
+        };
+        logging_data.writeItemOverwrite(try logRegisters(
+            log_time_start,
+            &timer,
+        ));
     }
     try logToString(
         &logging_data,


### PR DESCRIPTION
@mochalins 

This PR has the following key points:
1. Refactor `CONNECT` error checking logic
2. Non-blocking socket operation:
(a) Allowing user to cancel a command in case it is stuck in socket operation
(b) basically, point (a) will not happen anymore as it keep checking the socket status. Now, the command can return an error if the socket is closed by peer, 