### PR TITLE
Fix terminal stuck on exit command in windows

### DIFF
--- a/src/command.zig
+++ b/src/command.zig
@@ -2,16 +2,20 @@
 //! and execute commands. Furthermore, it includes the implementations of a few
 //! general purpose commands that facilitate easier use of the MMC CLI utility.
 
-const builtin = @import("builtin");
 const std = @import("std");
-const chrono = @import("chrono");
+const builtin = @import("builtin");
+
 const build = @import("build.zig.zon");
+const chrono = @import("chrono");
+
+const client_cli = @import("command/client_cli.zig");
+const mcl = @import("command/mcl.zig");
+const return_demo2 = @import("command/return_demo2.zig");
+const Config = @import("Config.zig");
+const io = @import("io.zig");
 const prompt = @import("prompt.zig");
 
 // Command modules.
-const mcl = @import("command/mcl.zig");
-const return_demo2 = @import("command/return_demo2.zig");
-const client_cli = @import("command/client_cli.zig");
 const mes07 = if (builtin.os.tag == .linux)
     @import("command/mes07.zig")
 else
@@ -19,8 +23,6 @@ else
         pub fn init(_: anytype) !void {}
         pub fn deinit() void {}
     };
-
-const Config = @import("Config.zig");
 
 pub const Registry = struct {
     mapping: std.StringArrayHashMap(Command),
@@ -902,6 +904,8 @@ fn clear(_: [][]const u8) !void {
 }
 
 fn exit(_: [][]const u8) !void {
+    prompt.close.store(true, .monotonic);
+    io.deinit();
     deinit();
     std.process.exit(1);
 }


### PR DESCRIPTION
I faced this problem before when developing the cli in windows.

When we call exit() in command.zig, the behavior of the following line in windows strictly exit the program without the program allowed to run any defer or errdefer. This cause an issue that the terminal stuck (using nushell) or reset the terminal (powershell) after we call exit command.

`std.process.exit(1);`

![Screenshot 2025-05-23 092015](https://github.com/user-attachments/assets/799d9f7e-ca8e-4726-a882-efd723b17bc6)

