### PR TITLE
Fix client disconnect failure on MMC server crash

### DIFF
--- a/src/command/client_cli.zig
+++ b/src/command/client_cli.zig
@@ -924,8 +924,8 @@ fn clientConnect(params: [][]const u8) !void {
 fn disconnect() !void {
     if (main_socket) |s| {
         std.log.info(
-            "Disconnecting from server {}",
-            .{try s.getRemoteEndPoint()},
+            "Disconnecting from server {s}:{}",
+            .{ IP_address, port },
         );
         s.close();
         for (lines) |line| {


### PR DESCRIPTION
When a connection with a server is broken by the server, the CLI side socket fails to return a remote endpoint. This caused the `disconnect` command to fail before it could reset local connection state, thus keeping the CLI in an unrecoverable state where it is unable to connect or disconnect.