### PR TITLE
Remove network dependency on `mmc_client`

### DIFF
--- a/src/command.zig
+++ b/src/command.zig
@@ -915,8 +915,6 @@ fn setLog(params: [][]const u8) !void {
         );
     };
 
-    std.debug.print("{s}\n", .{file_path});
-
     if (std.ascii.eqlIgnoreCase("stop", mode_str)) {
         if (log_file) |f| {
             f.close();

--- a/src/command/mmc_client/Carrier.zig
+++ b/src/command/mmc_client/Carrier.zig
@@ -17,29 +17,27 @@ pub fn waitState(
     var ids: std.ArrayList(u32) = .empty;
     defer ids.deinit(allocator);
     try ids.append(allocator, id);
-    try api.request.info.system.encode(
-        allocator,
-        &client.writer.writer,
-        .{
-            .line_id = line_id,
-            .carrier = true,
-            .source = .{
-                .carriers = .{ .ids = ids },
-            },
-        },
-    );
-    const msg = try client.writer.toOwnedSlice();
     var wait_timer = try std.time.Timer.start();
-    defer client.allocator.free(msg);
     while (true) {
         if (timeout != 0 and
             wait_timer.read() > timeout * std.time.ns_per_ms)
             return error.WaitTimeout;
-        try command.checkCommandInterrupt();
-        try client.net.send(msg);
-        const resp = try client.net.receive(client.allocator);
-        defer client.allocator.free(resp);
-        var reader: std.Io.Reader = .fixed(resp);
+        {
+            const writer = try client.net.getWriter();
+            try api.request.info.system.encode(
+                allocator,
+                writer,
+                .{
+                    .line_id = line_id,
+                    .carrier = true,
+                    .source = .{
+                        .carriers = .{ .ids = ids },
+                    },
+                },
+            );
+            try writer.flush();
+        }
+        var reader = try client.net.getReader();
         var system = try api.response.info.system.decode(
             client.allocator,
             &reader,


### PR DESCRIPTION
I am going to ask your opinion on the new reader and writer implementation for the `mmc_client` @mochalins 

The problem lies on decoding the message. When we pass the socket reader to the protobuf decode, the decode does not get `error.EndOfStream` from reader.takeByte() as you handle in [line 542](https://github.com/Arwalk/zig-protobuf/pull/121/files#diff-209ffe397996c1f8fdb5b78e01ac46653868ab38694c2732c299384fed02633cR542). The reader from socket will keep waiting for the next incoming message from the remote end, so it stuck.

I have thinking a lot and do not know any other option from the zig-protobuf side, since it is make sense to handle the `error.EndOfStream` like what you do. What I did on my side in this PR is I re-create another reader using any message received by the socket reader.

If you have better alternative for the reader, let's discuss it here.