### PR TITLE
Return `Overcurrent` if a command makes a carrier to be overcurrent

### DIFF
--- a/src/command/mmc_client/Carrier.zig
+++ b/src/command/mmc_client/Carrier.zig
@@ -49,6 +49,7 @@ pub fn waitState(
         defer track.deinit(client.allocator);
         if (track.line != line) return error.InvalidResponse;
         const carrier = track.carrier_state.pop() orelse return error.InvalidResponse;
+        if (carrier.state == .CARRIER_STATE_OVERCURRENT) return error.Overcurrent;
         if (carrier.state == state) return;
     }
 }


### PR DESCRIPTION
This changes will prevent `FILE` command to continue running when one of a command causing a carrier to be overcurrent.

PS: The file shall contain `waitIsolate`, `waitMoveCarrier`, or `waitPull`