### PR TITLE
zignet proper sockaddr storage

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -13,8 +13,8 @@
             .hash = "network-0.1.0-Pm-AgiMxAQCuaDrGAfSxVHeozUQ2gU3jINGLFxJ1Zpld",
         },
         .zignet = .{
-            .url = "https://github.com/aaumar25/zignet/archive/78a4f59.tar.gz",
-            .hash = "zignet-0.1.1-BAu-r0GHAAACi9E4RgvaZKYCtlZsvtt2llRB23hbs9Q9",
+            .url = "https://github.com/aaumar25/zignet/archive/7350acf.tar.gz",
+            .hash = "zignet-0.1.1-BAu-r5WJAACLSIB3CYLSrby4nZq7YjHX8MBjvHdCMGYH",
         },
         .chrono = .{
             .url = "https://github.com/pmotionf/chrono/archive/31e31b0.tar.gz",


### PR DESCRIPTION
closes #198

It saves the scope ID correctly, thus doing mmc-logging is allowed again in Linux.

However, further fix shall be implemented in the case after connected to IPv6 server -> disconnect -> reconnect always fails because in Linux passing the IPv6 address to resolve the hostname does not work.