### PR TITLE
Allow suffix to be used on parameters

### DIFF
--- a/src/modules/mmc_client/commands/assert_hall.zig
+++ b/src/modules/mmc_client/commands/assert_hall.zig
@@ -14,6 +14,8 @@ pub fn impl(params: [][]const u8) !void {
         const input = params[1];
         var suffix: ?usize = null;
         for (input, 0..) |c, i| if (!std.ascii.isDigit(c)) {
+            // Only valid suffix for axis_id is either 'a' or "axis".
+            if (c != 'a') return error.InvalidCharacter;
             suffix = i;
             break;
         };

--- a/src/modules/mmc_client/commands/assert_location.zig
+++ b/src/modules/mmc_client/commands/assert_location.zig
@@ -14,6 +14,8 @@ pub fn impl(params: [][]const u8) !void {
         const input = params[1];
         var suffix: ?usize = null;
         for (input, 0..) |c, i| if (!std.ascii.isDigit(c)) {
+            // Only valid suffix for carrier id is either 'c' or "carrier".
+            if (c != 'c') return error.InvalidCharacter;
             suffix = i;
             break;
         };

--- a/src/modules/mmc_client/commands/axis_carrier.zig
+++ b/src/modules/mmc_client/commands/axis_carrier.zig
@@ -14,6 +14,8 @@ pub fn impl(params: [][]const u8) !void {
         const input = params[1];
         var suffix: ?usize = null;
         for (input, 0..) |c, i| if (!std.ascii.isDigit(c)) {
+            // Only valid suffix for axis_id is either 'a' or "axis".
+            if (c != 'a') return error.InvalidCharacter;
             suffix = i;
             break;
         };

--- a/src/modules/mmc_client/commands/carrier_axis.zig
+++ b/src/modules/mmc_client/commands/carrier_axis.zig
@@ -13,6 +13,8 @@ pub fn impl(params: [][]const u8) !void {
         const input = params[1];
         var suffix: ?usize = null;
         for (input, 0..) |c, i| if (!std.ascii.isDigit(c)) {
+            // Only valid suffix for carrier id is either 'c' or "carrier".
+            if (c != 'c') return error.InvalidCharacter;
             suffix = i;
             break;
         };

--- a/src/modules/mmc_client/commands/carrier_location.zig
+++ b/src/modules/mmc_client/commands/carrier_location.zig
@@ -14,6 +14,8 @@ pub fn impl(params: [][]const u8) !void {
         const input = params[1];
         var suffix: ?usize = null;
         for (input, 0..) |c, i| if (!std.ascii.isDigit(c)) {
+            // Only valid suffix for carrier id is either 'c' or "carrier".
+            if (c != 'c') return error.InvalidCharacter;
             suffix = i;
             break;
         };

--- a/src/modules/mmc_client/commands/isolate.zig
+++ b/src/modules/mmc_client/commands/isolate.zig
@@ -14,6 +14,8 @@ pub fn impl(params: [][]const u8) !void {
         const input = params[1];
         var suffix: ?usize = null;
         for (input, 0..) |c, i| if (!std.ascii.isDigit(c)) {
+            // Only valid suffix for axis_id is either 'a' or "axis".
+            if (c != 'a') return error.InvalidCharacter;
             suffix = i;
             break;
         };
@@ -40,6 +42,8 @@ pub fn impl(params: [][]const u8) !void {
         const input = params[3];
         var suffix: ?usize = null;
         for (input, 0..) |c, i| if (!std.ascii.isDigit(c)) {
+            // Only valid suffix for carrier id is either 'c' or "carrier".
+            if (c != 'c') return error.InvalidCharacter;
             suffix = i;
             break;
         };

--- a/src/modules/mmc_client/commands/move.zig
+++ b/src/modules/mmc_client/commands/move.zig
@@ -12,6 +12,8 @@ pub fn posAxis(params: [][]const u8) !void {
         const input = params[2];
         var suffix: ?usize = null;
         for (input, 0..) |c, i| if (!std.ascii.isDigit(c)) {
+            // Only valid suffix for axis_id is either 'a' or "axis".
+            if (c != 'a') return error.InvalidCharacter;
             suffix = i;
             break;
         };
@@ -47,6 +49,8 @@ pub fn spdAxis(params: [][]const u8) !void {
         const input = params[2];
         var suffix: ?usize = null;
         for (input, 0..) |c, i| if (!std.ascii.isDigit(c)) {
+            // Only valid suffix for axis_id is either 'a' or "axis".
+            if (c != 'a') return error.InvalidCharacter;
             suffix = i;
             break;
         };
@@ -87,6 +91,8 @@ fn impl(
         const input = params[1];
         var suffix: ?usize = null;
         for (input, 0..) |c, i| if (!std.ascii.isDigit(c)) {
+            // Only valid suffix for carrier id is either 'c' or "carrier".
+            if (c != 'c') return error.InvalidCharacter;
             suffix = i;
             break;
         };

--- a/src/modules/mmc_client/commands/pull.zig
+++ b/src/modules/mmc_client/commands/pull.zig
@@ -28,6 +28,8 @@ fn impl(
         const input = params[1];
         var suffix: ?usize = null;
         for (input, 0..) |c, i| if (!std.ascii.isDigit(c)) {
+            // Only valid suffix for axis_id is either 'a' or "axis".
+            if (c != 'a') return error.InvalidCharacter;
             suffix = i;
             break;
         };
@@ -40,6 +42,8 @@ fn impl(
         const input = params[2];
         var suffix: ?usize = null;
         for (input, 0..) |c, i| if (!std.ascii.isDigit(c)) {
+            // Only valid suffix for carrier id is either 'c' or "carrier".
+            if (c != 'c') return error.InvalidCharacter;
             suffix = i;
             break;
         };

--- a/src/modules/mmc_client/commands/push.zig
+++ b/src/modules/mmc_client/commands/push.zig
@@ -31,6 +31,8 @@ fn impl(
         const input = params[1];
         var suffix: ?usize = null;
         for (input, 0..) |c, i| if (!std.ascii.isDigit(c)) {
+            // Only valid suffix for axis_id is either 'a' or "axis".
+            if (c != 'a') return error.InvalidCharacter;
             suffix = i;
             break;
         };
@@ -43,6 +45,8 @@ fn impl(
         const input = params[2];
         var suffix: ?usize = null;
         for (input, 0..) |c, i| if (!std.ascii.isDigit(c)) {
+            // Only valid suffix for carrier id is either 'c' or "carrier".
+            if (c != 'c') return error.InvalidCharacter;
             suffix = i;
             break;
         };

--- a/src/modules/mmc_client/commands/set_carrier_id.zig
+++ b/src/modules/mmc_client/commands/set_carrier_id.zig
@@ -15,6 +15,8 @@ pub fn impl(params: [][]const u8) !void {
         const input = params[1];
         var suffix: ?usize = null;
         for (input, 0..) |c, i| if (!std.ascii.isDigit(c)) {
+            // Only valid suffix for carrier id is either 'c' or "carrier".
+            if (c != 'c') return error.InvalidCharacter;
             suffix = i;
             break;
         };
@@ -27,6 +29,8 @@ pub fn impl(params: [][]const u8) !void {
         const input = params[1];
         var suffix: ?usize = null;
         for (input, 0..) |c, i| if (!std.ascii.isDigit(c)) {
+            // Only valid suffix for carrier id is either 'c' or "carrier".
+            if (c != 'c') return error.InvalidCharacter;
             suffix = i;
             break;
         };

--- a/src/modules/mmc_client/commands/wait.zig
+++ b/src/modules/mmc_client/commands/wait.zig
@@ -13,6 +13,8 @@ pub fn isolate(params: [][]const u8) !void {
         const input = params[1];
         var suffix: ?usize = null;
         for (input, 0..) |c, i| if (!std.ascii.isDigit(c)) {
+            // Only valid suffix for carrier id is either 'c' or "carrier".
+            if (c != 'c') return error.InvalidCharacter;
             suffix = i;
             break;
         };
@@ -44,6 +46,8 @@ pub fn moveCarrier(params: [][]const u8) !void {
         const input = params[1];
         var suffix: ?usize = null;
         for (input, 0..) |c, i| if (!std.ascii.isDigit(c)) {
+            // Only valid suffix for carrier id is either 'c' or "carrier".
+            if (c != 'c') return error.InvalidCharacter;
             suffix = i;
             break;
         };
@@ -76,6 +80,8 @@ pub fn pull(params: [][]const u8) !void {
         const input = params[1];
         var suffix: ?usize = null;
         for (input, 0..) |c, i| if (!std.ascii.isDigit(c)) {
+            // Only valid suffix for carrier id is either 'c' or "carrier".
+            if (c != 'c') return error.InvalidCharacter;
             suffix = i;
             break;
         };
@@ -109,6 +115,8 @@ pub fn axisEmpty(params: [][]const u8) !void {
         const input = params[1];
         var suffix: ?usize = null;
         for (input, 0..) |c, i| if (!std.ascii.isDigit(c)) {
+            // Only valid suffix for axis_id is either 'a' or "axis".
+            if (c != 'a') return error.InvalidCharacter;
             suffix = i;
             break;
         };


### PR DESCRIPTION
This PR allows commands with axis parameter to allow suffix on the axis parameters. In addition, it also validates the suffix is match to the parameter type (axis or carrier)

Issues to be addressed on future PR: 
- Use filter on `ADD_LOG_INFO` and `REMOVE_LOG_INFO`